### PR TITLE
revert to Jasmine v2.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     "express-session": "^1.14.1"
   },
   "devDependencies": {
-    "jasmine": "^2.5.0"
+    "jasmine": "^2.4.1"
   }
 }


### PR DESCRIPTION
Jasmine v2.5.0 contains a bug where output isn't being logged to the
console.

closes #26